### PR TITLE
Delete following

### DIFF
--- a/authors/urls_author.py
+++ b/authors/urls_author.py
@@ -22,5 +22,5 @@ urlpatterns = [
 
     path('<str:author_id>/followings/', FollowingList.as_view(), name='following-list'),
     re_path(r'^(?P<author_id>[^/]*)/followings/(?P<foreign_author_url>.*)$',
-            internally_send_friend_request, name="friend-request"),
+            FollowingDetail.as_view(), name="following-detail"),
 ]

--- a/authors/views.py
+++ b/authors/views.py
@@ -291,53 +291,6 @@ class InboxDetailView(RetrieveDestroyAPIView, InboxSerializerMixin):
 
         inbox_item.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
- 
-
-@extend_schema(
-    responses=FollowSerializer
-)
-@api_view(['POST'])
-@permission_classes([permissions.IsAuthenticated])
-def internally_send_friend_request(request, author_id, foreign_author_url):
-    """
-    **[Internal]** <br>
-    the /author/<author_id>/friend_request/<foreign_author_url>/ endpoint
-    - author_id: anything other than slash, but we hope it's a uuid
-    - foreign_author_url: anything, but we hope it's a valid url.
-
-    used only by local users, jwt authentication required. <br>
-    Its job is to fire a POST to the foreign author's inbox with a FriendRequest json object.
-    """
-    import requests
-
-    try:
-        author = Author.objects.get(id=author_id)
-    except:
-        return Response(status=status.HTTP_404_NOT_FOUND)
-
-    # get that foreign author's json object first
-    foreign_author_json = requests.get(foreign_author_url).json()
-
-    # check for foreign author validity
-    foreign_author_ser = AuthorSerializer(data=foreign_author_json)
-
-    if foreign_author_ser.is_valid():
-        foreign_author = foreign_author_ser.save()
-
-        if Follow.objects.filter(actor=author, object=foreign_author):
-            raise exceptions.PermissionDenied("duplicate follow object exists for the authors")
-
-        follow = Follow(
-            summary=f"{author.display_name} wants to follow {foreign_author.display_name}",
-            actor=author,
-            object=foreign_author
-        )
-
-        follow.save()
-        connector_service.notify_follow(follow, request=request)
-        return Response(FollowSerializer(follow).data)
-
-    return Response({'parsing foreign author': foreign_author_ser.errors}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 class FollowerList(ListAPIView):
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
@@ -503,3 +456,80 @@ class FollowingList(ListAPIView):
             raise exceptions.NotFound
  
         return author.followings.all()
+
+class FollowingDetail(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    @extend_schema(
+        responses=FollowSerializer()
+    )
+    def post(self, request, author_id, foreign_author_url):
+        """
+        **[Internal]** <br>
+        the /author/<author_id>/friend_request/<foreign_author_url>/ endpoint
+        - author_id: anything other than slash, but we hope it's a uuid
+        - foreign_author_url: anything, but we hope it's a valid url.
+
+        used only by local users, jwt authentication required. <br>
+        Its job is to fire a POST to the foreign author's inbox with a FriendRequest json object.
+        """
+
+        try:
+            author = Author.objects.get(id=author_id)
+        except:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        # get that foreign author's json object first
+        foreign_author_json = requests.get(foreign_author_url).json()
+
+        # check for foreign author validity
+        foreign_author_ser = AuthorSerializer(data=foreign_author_json)
+
+        if foreign_author_ser.is_valid():
+            foreign_author = foreign_author_ser.save()
+
+            if Follow.objects.filter(actor=author, object=foreign_author):
+                raise exceptions.PermissionDenied("duplicate follow object exists for the authors")
+
+            follow = Follow(
+                summary=f"{author.display_name} wants to follow {foreign_author.display_name}",
+                actor=author,
+                object=foreign_author
+            )
+
+            follow.save()
+            connector_service.notify_follow(follow, request=request)
+            return Response(FollowSerializer(follow).data)
+
+        return Response({'parsing foreign author': foreign_author_ser.errors}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    def delete(self, request, author_id, foreign_author_url):
+        """
+        ## Description: 
+        **[Internal]** <br>
+        Should be called when author_id's author no longer wants to follow foreign_author_url's author <br>
+        This can happen when the author is already following (status ACCEPTED) <br>
+        Or author wants to remove its friend/follow request (status PENDING)
+        ## Responses:
+        """
+        try:
+            author = Author.objects.get(id=author_id)
+            foreign_author = Author.objects.get(url=foreign_author_url)
+            follow_object = Follow.objects.get(actor=author, object=foreign_author)
+        except Author.DoesNotExist as e:
+            return Response(e.message, status=status.HTTP_404_NOT_FOUND)
+        except Follow.DoesNotExist:
+            error_msg = "the follow relationship does not exist between the two authors"
+            return Response(error_msg, status=status.HTTP_400_BAD_REQUEST)
+        
+        follow_object.delete()
+
+        # send a request to the foreign server telling them to delete the follower
+        request_url = foreign_author_url + "/followers/" + author.url
+        # ignoring the response here as we can't control the remote server
+        # but at least we tried to notify them 
+        requests.delete(request_url)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+        
+
+        

--- a/authors/views.py
+++ b/authors/views.py
@@ -512,6 +512,9 @@ class FollowingDetail(APIView):
         This can happen when the author is already following (status ACCEPTED) <br>
         Or author wants to remove its friend/follow request (status PENDING)
         ## Responses:
+        **204**: For successful DELETE request <br>
+        **400**: When the author is not following the other author <br>
+        **404**: When the follower or followee does not exist
         """
         try:
             author = Author.objects.get(id=author_id)

--- a/authors/views.py
+++ b/authors/views.py
@@ -532,7 +532,7 @@ class FollowingDetail(APIView):
             request_url = foreign_author_url + "/followers/" + author.url
         # ignoring the response here as we can't control the remote server
         # but at least we tried to notify them 
-        response = requests.delete(request_url, auth=("admin", "socialdistance"))
+        requests.delete(request_url, auth=(author.user.username, author.user.password))
         return Response(status=status.HTTP_204_NO_CONTENT)
         
 

--- a/authors/views.py
+++ b/authors/views.py
@@ -542,7 +542,11 @@ class FollowingDetail(APIView):
             requests.delete(request_url, auth=node.get_basic_auth_tuple())
         except Node.DoesNotExist:
             print("failed to notify remote server of the unfollowing")
-    
+            print("Reason: Remote Server not connected")
+        except requests.exceptions.RequestException as e:
+            print("failed to notify remote server of the unfollowing")
+            print("Reason: Remote Request Failed: " + e)
+
         return Response(status=status.HTTP_204_NO_CONTENT)
         
 

--- a/authors/views.py
+++ b/authors/views.py
@@ -525,10 +525,14 @@ class FollowingDetail(APIView):
         follow_object.delete()
 
         # send a request to the foreign server telling them to delete the follower
-        request_url = foreign_author_url + "/followers/" + author.url
+        
+        if (foreign_author_url.endswith("/")):
+            request_url = foreign_author_url + "followers/" + author.url
+        else:
+            request_url = foreign_author_url + "/followers/" + author.url
         # ignoring the response here as we can't control the remote server
         # but at least we tried to notify them 
-        requests.delete(request_url)
+        response = requests.delete(request_url, auth=("admin", "socialdistance"))
         return Response(status=status.HTTP_204_NO_CONTENT)
         
 

--- a/nodes/models.py
+++ b/nodes/models.py
@@ -32,6 +32,9 @@ class Node(models.Model):
     def get_basic_auth(self):
         return HTTPBasicAuth(self.username, self.password)
 
+    def get_basic_auth_tuple(self):
+        return (self.username, self.password)
+
 # https://stackoverflow.com/a/24025175
 # catch all request error and just print them out instead
 def silent_500(fn):


### PR DESCRIPTION
implement endpoint for removing following

Test Steps:
1. Run two servers, 8000 and 8001
2. Make sure the two servers are connected via adding the node
3. create author_A on 8000, author_B on 8001
4. make a POST request to the endpoint on 8000 to request author_A follow author_B
5. Notice a Follow object is created on both 8000 and 8001
6. [Optional] on 8001 accept the following request by modifying the Follow object
7. make a DELETE request to the endpoint on 8000 to delete the following
8. Notice the Follow object on both servers are deleted

Unknown Behaviour:
* If we want to remove a following request that is still in the pending state, there's no way we can delete the follow from the foreign server's inbox. (Also we can't guarantee the other server also uses PENDING and ACCEPTED statuses, I guess we'll see what we can do when we make the actual connection)

Note:
* Nothing is modified for the POST endpoint, just refactored into a APIView class since I need the same endpoint for DELETE.