### PR TITLE
Implement share API. Sort out url encoding for foreign authors.

### DIFF
--- a/authors/models.py
+++ b/authors/models.py
@@ -1,5 +1,6 @@
 import uuid
 from requests import Request
+from urllib.parse import unquote, quote
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.urls import reverse 
@@ -7,6 +8,7 @@ from django.contrib.auth.models import User
 from django.utils.translation import gettext_lazy as _
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
+
 
 # Create your models here.
 class Author(models.Model):
@@ -31,7 +33,7 @@ class Author(models.Model):
     
     def is_internal(self):
         try:
-            _ = Request('GET', self.id).prepare()
+            _ = Request('GET', unquote(self.id)).prepare()
             return False
         except:
             return True

--- a/authors/serializers.py
+++ b/authors/serializers.py
@@ -4,6 +4,8 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 from django.db.models import Q
 
+from urllib.parse import quote, unquote
+
 from rest_framework import exceptions, serializers
 
 from .models import Author, Follow, InboxObject
@@ -49,18 +51,26 @@ class AuthorSerializer(serializers.ModelSerializer):
         return instance
 
     @staticmethod
+    def quote(url):
+        """
+        method used to quote the author id for use in urls
+        """
+        return quote(url, safe='')
+
+    @staticmethod
     def _upcreate(validated_data):
         """
         update or create Author from validated data, based on url OR id.
         """
         try:
             author = Author.objects.get(
-                Q(id=validated_data['id']) | Q(url=validated_data['url']))
+                Q(id=AuthorSerializer.quote(validated_data['id'])) | Q(url=validated_data['url']))
             updated_author = AuthorSerializer._update(author, validated_data)
         except Author.MultipleObjectsReturned:
             raise exceptions.ParseError(
                 "multiple author objects with the same id or url is detected. How did you do that?")
         except:
+            validated_data['id'] = AuthorSerializer.quote(validated_data.get('id', str(uuid.uuid4())))
             updated_author = Author.objects.create(**validated_data)
 
         return updated_author

--- a/authors/tests.py
+++ b/authors/tests.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from django.test import TestCase
 from rest_framework.test import APIClient, APIRequestFactory, force_authenticate
 from rest_framework_simplejwt.tokens import RefreshToken
+from urllib import parse
 
 from django.contrib.auth.models import User
 from authors.models import Author, Follow, InboxObject
@@ -21,6 +22,8 @@ def client_with_auth(user, client):
     client.credentials(HTTP_AUTHORIZATION=f'Bearer {refresh.access_token}')
     return client
 
+def quote(string):
+    return parse.quote(string, safe='')
 
 class FollowTestCase(TestCase):
     DATA = {
@@ -121,7 +124,7 @@ class AuthorSerializerTestCase(TestCase):
         assert s.is_valid()
         foreign_author = s.save()  # an Author object
 
-        self.assertEqual(foreign_author.id, self.FOREIGN_AUTHOR_A_DATA['id'])
+        self.assertEqual(foreign_author.id, quote(self.FOREIGN_AUTHOR_A_DATA['id']))
         self.assertEqual(foreign_author.url, self.FOREIGN_AUTHOR_A_DATA['url'])
         self.assertEqual(foreign_author.display_name, self.FOREIGN_AUTHOR_A_DATA['displayName'])
         self.assertEqual(foreign_author.host, self.FOREIGN_AUTHOR_A_DATA['host'])
@@ -137,7 +140,7 @@ class AuthorSerializerTestCase(TestCase):
         assert s.is_valid()
         foreign_author = s.save()  # an Author object
 
-        self.assertEqual(foreign_author.id, self.FOREIGN_AUTHOR_B_DATA['id'])
+        self.assertEqual(foreign_author.id, quote(self.FOREIGN_AUTHOR_B_DATA['id']))
         self.assertEqual(foreign_author.url, self.FOREIGN_AUTHOR_B_DATA['url'])
         self.assertEqual(foreign_author.host, self.FOREIGN_AUTHOR_B_DATA['host'])
         self.assertEqual(foreign_author.display_name, self.FOREIGN_AUTHOR_B_DATA['displayName'])

--- a/authors/views.py
+++ b/authors/views.py
@@ -223,6 +223,8 @@ class InboxListView(ListCreateAPIView, InboxSerializerMixin):
         if serializer.is_valid():
             # save the item to database, could be post or like or FR
             item = serializer.save()
+            if hasattr(item, 'update_fields_with_request'):
+                item.update_fields_with_request(request)
             # wrap the item in an inboxObject, links with author
             item_as_inbox = InboxObject(content_object=item, author=author)
             item_as_inbox.save()

--- a/posts/models.py
+++ b/posts/models.py
@@ -76,9 +76,15 @@ class Post(models.Model):
         return self.comment_set.count()
 
     # used by serializer
-    def update_fields_with_request(self, request):
+    def update_fields_with_request(self, request=None):
+        if not request:
+            return
         self.url = request.build_absolute_uri(self.get_absolute_url())
         self.host = request.build_absolute_uri('/') # points to the server root
+        if not self.origin:
+            self.origin = self.url
+        if not self.source:
+            self.source = self.url
         self.save()
 
 class Comment(models.Model):

--- a/posts/serializers.py
+++ b/posts/serializers.py
@@ -14,8 +14,11 @@ class PostSerializer(serializers.ModelSerializer):
     type = serializers.CharField(default="post", source="get_api_type", read_only=True)
     # public id should be the full url
     id = serializers.CharField(source="get_public_id", read_only=True)
+    source = serializers.URLField(required=False, allow_blank=True)
+    origin = serializers.URLField(required=False, allow_blank=True)
+
     count = serializers.IntegerField(source="count_comments", read_only=True)
-    published = serializers.DateTimeField(read_only=True)
+    published = serializers.DateTimeField(required=False)
     author = AuthorSerializer(required=False)
     comments = serializers.URLField(source="build_comments_url", read_only=True)
 

--- a/posts/tests.py
+++ b/posts/tests.py
@@ -367,7 +367,7 @@ class CommentListTestCase(TestCase):
         )
         self.assertEqual(res.status_code, 200)
         self.assertEqual(len(Comment.objects.all()), 3)
-        assert len(Author.objects.filter(id=self.payload["author"]["url"])) == 1
+        assert len(Author.objects.filter(url=self.payload["author"]["url"])) == 1
 
 class LikeTestCase(TestCase):
     def setup_objects(self):

--- a/posts/urls_post.py
+++ b/posts/urls_post.py
@@ -4,5 +4,6 @@ from .views import *
 
 urlpatterns = [
     path('<str:post_id>/likes/', LikesPostList.as_view(), name="like-post-list"),
+    path('<str:post_id>/share/', share_post, name="share-post"),
     path('<str:post_id>/comments/<str:comment_id>/likes/', LikesCommentList.as_view(), name="like-comment-list"),
 ]


### PR DESCRIPTION
new endpoint:
- /author/aid/post/pid/share/, will create a post whose author is the authenticated user.

new usable fields:
- Post.source: url to the post before it was shared.
- Post.origin: url to the very original post.

new internal changes:
- now author_id is url encoded (i.e. url quoted) before storing in database. and unquoted when using as a url.
