### PR TITLE
add serializer to inbox list

### DIFF
--- a/authors/views.py
+++ b/authors/views.py
@@ -116,6 +116,7 @@ class InboxSerializerMixin:
 class InboxListView(ListCreateAPIView, InboxSerializerMixin):
     # permission_classes = [permissions.IsAuthenticated]
     pagination_class = InboxObjectsPagination
+    serializer_class = InboxObjectSerializer
 
     def get(self, request, author_id):
         """


### PR DESCRIPTION
serializer class is required to make swagger UI display page and size query info